### PR TITLE
Update 2 NuGet dependencies

### DIFF
--- a/src/Mako-IoT.Device.Services.Logging.Sinks.SdCard/Mako-IoT.Device.Services.Logging.Sinks.SdCard.nfproj
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.SdCard/Mako-IoT.Device.Services.Logging.Sinks.SdCard.nfproj
@@ -29,8 +29,9 @@
     <Reference Include="nanoFramework.DependencyInjection">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Events">
-      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.15\lib\nanoFramework.Runtime.Events.dll</HintPath>
+    <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Runtime">
       <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.6\lib\nanoFramework.System.Runtime.dll</HintPath>
@@ -38,8 +39,8 @@
     <Reference Include="nanoFramework.System.Text">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.41.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.41\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.45.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.45\lib\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/Mako-IoT.Device.Services.Logging.Sinks.SdCard/packages.config
+++ b/src/Mako-IoT.Device.Services.Logging.Sinks.SdCard/packages.config
@@ -3,8 +3,8 @@
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.41" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.45" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.6" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.Runtime.Events from 1.11.15 to 1.11.18</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.41 to 1.1.45</br>
[version update]

### :warning: This is an automated update. :warning:
